### PR TITLE
Fixed #15: implemented support for django cache framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,17 @@ We have provided a small wrapper and lock implementation for use with Redis.
 
     # Use!
 
+Django's cache framework
+-------------------------
+
+If you want to integrate PyMemoize in a django project, you can use [Django's cache framework](https://docs.djangoproject.com/en/1.11/topics/cache/#accessing-the-cache) as a store for memoized values. This way, you can leverage [any cache that has a Django integration](https://docs.djangoproject.com/en/1.11/topics/cache/#setting-up-the-cache), such as Redis, Memcached, or even database cache.
+
+    import memoize.djangocache
+
+    store = memoize.djangocache.Cache('default')
+    memo = memoize.Memoizer(store, namespace='memoize')
+
+If you want to use another cache declared in your django settings, you can replace `default` with the name of the cache.
 
 Store Interface
 ---------------
@@ -375,10 +386,3 @@ Return a lock object as specified by the locking section below.
 Return the time-to-live of the given key as a float, or None if it does not exist or will not expire. If the native expiry mechanism does not support float times then take care that the returned value is less than the "real" expiry time.
 
 ie. If using a store that has second resolution, return: `native_ttl - 1`.
-
-
-
-
-
-
-

--- a/memoize/djangocache.py
+++ b/memoize/djangocache.py
@@ -1,0 +1,43 @@
+import time
+
+from django.conf import settings
+from django.core.cache import caches
+
+
+class Cache(object):
+    """
+    Will simply proxy cache calls to django's internal
+    cache framework
+    """
+    def __init__(self, name='default'):
+        self._cache = caches[name]
+
+    def get(self, key):
+        return self._cache.get(key)
+
+    def delete(self, key):
+        return self._cache.delete(key)
+
+    def expire_at(self, key, max_age):
+        raise NotImplementedError('Unsupported by django cache backend')
+
+    def exists(self, key):
+        return self.get(key) is not None
+
+    def __getitem__(self):
+        return self.get(key)
+
+    def __setitem__(self, key, value):
+        expiry = value[2]
+        seconds = None
+        if expiry:
+            # this is a bit ugly, but django's cache framework
+            # requires an expiry in seconds
+            # to we reverse-compute that value from the expiry given in the
+            # data tuple
+            now = time.time()
+            seconds = int(expiry - now)
+        return self._cache.set(key, value, seconds)
+
+    def __delitem__(key):
+        return self.delete(key)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,3 @@
 nose
 coveralls
+django

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,0 +1,44 @@
+import memoize.djangocache
+
+import django
+from django.test import TestCase
+from django.core.cache import caches
+
+
+class DjangoTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from django.test.utils import setup_test_environment
+        from django.core.management import call_command
+
+        from django.conf import settings
+        """
+        This is mandatory to spin up django
+        """
+        settings.configure(
+            INSTALLED_APPS=[],
+            DATABASES={
+                'default': {
+                    'NAME': ':memory:', 'ENGINE': 'django.db.backends.sqlite3'}
+            },
+        )
+        django.setup()
+        setup_test_environment()
+        super(DjangoTest, cls).setUpClass()
+
+    def test_can_memoize_using_django_cache(self):
+        cache = caches['default']
+
+        def f(number):
+            return number
+
+        store = memoize.djangocache.Cache('default')
+        memo = memoize.Memoizer(store)
+
+        self.assertFalse(store.exists('test'))
+
+        r = memo.get('test', f, (1,), max_age=16)
+
+        self.assertEqual(r, 1)
+        self.assertEqual(cache.get('test')[-1], 1)
+        self.assertTrue(store.exists('test'))

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = py26,py27,py31,py32,py33,pypy
+envlist = py26,py27,py31,py32,py33,py34,py35,py36,pypy
 [testenv]
 commands = nosetests --with-cover --cover-package=memoize --cover-branches
-deps = 
+deps =
 	-r{toxinidir}/test_requirements.txt


### PR DESCRIPTION
This PR adds support for django's cache framework, as described in #15.

A couple of notes:

- I've added a basic test, but this may be not enough. It's a bit complex for me to test this more thoroughly because this would require mocking and due to the wide range of supported Python versions, I don't know how to do that properly without introducing more dependencies
- I've added py34, py35 and py36 env in `tox.ini`
- Ive added Django to test dependencies (this is required to run the django tests)
- This implementation does not support ttl or locking. Tll is not currently doable within django (see [this question](https://stackoverflow.com/questions/19255736/how-to-get-expiration-time-from-cache) for example), locking is implementable I think, I'm just not really familiar with the underlying logic.

Tell me if you need some fixes or have any question.