### PR TITLE
Do a little refactor to make code more readable

### DIFF
--- a/memoize/core.py
+++ b/memoize/core.py
@@ -79,7 +79,7 @@ class Memoizer(object):
             self._has_expired(data, opts)
 
     def _etag_not_match(self, old_etag, etag):
-        return etag is not None and etag != old_etag:
+        return etag is not None and etag != old_etag
 
     def get(self, key, func=None, args=(), kwargs=None, **opts):
         """Manually retrieve a value from the cache, calculating as needed.

--- a/memoize/core.py
+++ b/memoize/core.py
@@ -257,7 +257,8 @@ class MemoizedFunction(object):
         # Insert kwargs into the args list by name.
         orig_args = list(args)
         args = []
-        for i, name in enumerate(spec_args):
+
+        for name in spec_args:
             if name in kwargs:
                 args.append(kwargs.pop(name))
             elif orig_args:

--- a/memoize/core.py
+++ b/memoize/core.py
@@ -75,7 +75,7 @@ class Memoizer(object):
         2. the key is expired
         for these situation, the method will return True
         '''
-        return self._etag_not_match(data[EXPIRY_INDEX], opts.get('etag')) or \
+        return self._etag_not_match(data[ETAG_INDEX], opts.get('etag')) or \
             self._has_expired(data, opts)
 
     def _etag_not_match(self, old_etag, etag):


### PR DESCRIPTION
Hi, @mikeboers 
I have a project which is working with *PyMemoize*
And I'm curious of the implementation, after hack into the code, I found that the `_expand_opts` which is defined in the `Memoizer` class is do too much things.  (the same method which is define in `MemoizedFunction` class is fine), so I'm try to rename it to `_get_key_store` method, which include `_expand_opts` process and add the potential namespace.  It has the same logic as `_expand_opts` before..

And so does the `_has_expired` method, I think that the `etag` doesn't match isn't belong to the expired situation.  So I have try to extract out a new method named `_cache_missed`, which is compose of `_has_expired` method(only check for the time expired) and `_etag_not_match` method(only check for the etag)

And finally, in the key calculating process in the `MemoizedFunction`, I found that `for i, name in enumerate(spec_args):`, the index is useless.  So I have remove it too.  Because it was just about the refactor of *private* method, so I don't add more test cases for it.  As the result, the UT is passed too :)

What do you think about it?  I hope it can make the code more clearer :)