### PR TITLE
Prevent sleep from being given a negative value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.6"
     - "2.7"
     - "pypy"
     - "3.3"
@@ -12,7 +11,7 @@ install:
   - pip install .
   - pip install -r test_requirements.txt
 
-script: 
+script:
   - nosetests --with-cover --cover-branches --cover-package=memoize
 
 after_success:

--- a/memoize/redis.py
+++ b/memoize/redis.py
@@ -48,8 +48,8 @@ class Lock(object):
                self.db.getset(self.key, expires) == current_value:
                     return True
 
-            timeout -= delay
             time.sleep(min(timeout, delay))
+            timeout -= delay
             delay *= 2
 
         return False


### PR DESCRIPTION
I ran into this error:

```
ValueError: sleep length must be non-negative

memoize/redis.py in acquire at line 52
```

On this line of code:

```python
time.sleep(min(timeout, delay))
```

with variables within that method of:

```python
delay = 6.4
timeout = -2.7
expires = 1538124182.0212266
```

I'm not sure what the correct fix is, but here's a suggestion